### PR TITLE
docs: add allowed-tools configuration to setup-prettier command

### DIFF
--- a/claude-code-commands/setup-prettier.md
+++ b/claude-code-commands/setup-prettier.md
@@ -1,5 +1,6 @@
 ---
 description: "Setup Prettier for consistent code formatting"
+allowed-tools: Edit(*), Write(*), Bash(pnpm:*), Bash(bun:*), Bash(mkdir:*), LS(*)
 ---
 
 # Instructions


### PR DESCRIPTION
## Summary
• Added `allowed-tools` configuration to the setup-prettier command documentation
• Specifies allowed tools for the command: Edit, Write, Bash (pnpm, bun, mkdir), and LS operations

## Test plan
- [x] Verify the allowed-tools configuration is properly formatted in the frontmatter
- [x] Confirm the documentation still renders correctly

🤖 Generated with Claude Code